### PR TITLE
Make this more docker friendly

### DIFF
--- a/00-vault-start.sh
+++ b/00-vault-start.sh
@@ -2,6 +2,7 @@
 pkill vault
 export VAULT_LOG_FORMAT=json
 export VAULT_ADDR=http://127.0.0.1:8200
+export VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200
 unset VAULT_TOKEN
 rm -f ~/.vault-token 
 


### PR DESCRIPTION
Exposing vault on 0.0.0.0 instead of 127.0.0.1 makes it easier to handle port forwarding inside of docker.